### PR TITLE
Add ability to use rolling primitives with pandas' offset aliases (#1…

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,7 @@ Release Notes
 Future Release
 ==============
     * Enhancements
+        * Add ability to use offset alias strings as inputs to rolling primitives (:pr:`1809`)
     * Fixes
     * Changes
         * Add autonormalize as an add-on library (:pr:`1840`)
@@ -21,7 +22,7 @@ Future Release
         * Upgrade tests to use compose version 0.8.0 (:pr:`1856`)
 
     Thanks to the following people for contributing to this release:
-    :user:`dvreed77`, :user:`gsheni`, :user:`thehomebrewnerd`, :user:`tuethan1999`
+    :user:`dvreed77`, :user:`gsheni`, :user:`thehomebrewnerd`, :user:`tamargrey`,:user:`tuethan1999`
 
 v1.4.0 Jan 10, 2022
 ===================

--- a/featuretools/primitives/standard/rolling_transform_primitive.py
+++ b/featuretools/primitives/standard/rolling_transform_primitive.py
@@ -6,7 +6,10 @@ from woodwork.logical_types import Datetime, Double
 from featuretools.primitives.base.transform_primitive_base import (
     TransformPrimitive
 )
-from featuretools.primitives.utils import _roll_series_with_gap
+from featuretools.primitives.utils import (
+    _apply_roll_with_offset_gap,
+    _roll_series_with_gap
+)
 
 
 class RollingMax(TransformPrimitive):
@@ -21,14 +24,38 @@ class RollingMax(TransformPrimitive):
         Input datetimes should be monotonic.
 
     Args:
-        window_length (int): The number of rows to be included in each frame. For data
-            with a uniform sampling frequency, for example of one day, the window_length will
-            correspond to a period of time, in this case, 7 days for a window_length of 7.
-        gap (int, optional): The number of rows backward from the target instance before the
-            window of usable data begins. Defaults to 0, which will include the target instance
-            in the window.
-        min_periods (int, optional): Minimum number of observations required for a window to have a value.
-            Can only be as large as window_length. Defaults to 1.
+        window_length (int, string, optional): Specifies the amount of data included in each window.
+            If an integer is provided, will correspond to a number of rows. For data with a uniform sampling frequency,
+            for example of one day, the window_length will correspond to a period of time, in this case,
+            7 days for a window_length of 7.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time that each window should span.
+            The list of available offset aliases, can be found at
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases.
+            Defaults to 3.
+        gap (int, string, optional): Specifies a gap backwards from each instance before the
+            window of usable data begins. If an integer is provided, will correspond to a number of rows.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time between a target instance and the beginning of its window.
+            Defaults to 0, which will include the target instance in the window.
+        min_periods (int, optional): Minimum number of observations required for performing calculations
+            over the window. Can only be as large as window_length when window_length is an integer.
+            When window_length is an offset alias string, this limitation does not exist, but care should be taken
+            to not choose a min_periods that will always be larger than the number of observations in a window.
+            Defaults to 1.
+
+    Note:
+        Only offset aliases with fixed frequencies can be used when defining gap and window_length.
+        This means that aliases such as `M` or `W` cannot be used, as they can indicate different
+        numbers of days. ('M', because different months are different numbers of days;
+        'W' because week will indicate a certain day of the week, like W-Wed, so that will
+        indicate a different number of days depending on the anchoring date.)
+
+    Note:
+        When using an offset alias to define `gap`, an offset alias must also be used to define `window_length`.
+        This limitation does not exist when using an offset alias to define `window_length`. In fact,
+        if the data has a uniform sampling frequency, it is preferable to use a numeric `gap` as it is more
+        efficient.
 
     Examples:
         >>> import pandas as pd
@@ -52,6 +79,14 @@ class RollingMax(TransformPrimitive):
         >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
         >>> rolling_max(times, [4, 3, 2, 1, 0]).tolist()
         [nan, nan, 4.0, 3.0, 2.0]
+
+        We can also set the window_length and gap using offset alias strings.
+
+        >>> import pandas as pd
+        >>> rolling_max = RollingMax(window_length='3min', gap='1min')
+        >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
+        >>> rolling_max(times, [4, 3, 2, 1, 0]).tolist()
+        [nan, 4.0, 4.0, 4.0, 3.0]
     """
     name = "rolling_max"
     input_types = [ColumnSchema(logical_type=Datetime, semantic_tags={'time_index'}), ColumnSchema(semantic_tags={'numeric'})]
@@ -69,6 +104,10 @@ class RollingMax(TransformPrimitive):
                                                   self.window_length,
                                                   gap=self.gap,
                                                   min_periods=self.min_periods)
+
+            if isinstance(self.gap, str):
+                additional_args = (self.gap, max, self.min_periods)
+                return rolled_series.apply(_apply_roll_with_offset_gap, args=additional_args).values
             return rolled_series.max().values
         return rolling_max
 
@@ -84,14 +123,39 @@ class RollingMin(TransformPrimitive):
         Input datetimes should be monotonic.
 
     Args:
-        window_length (int): The number of rows to be included in each frame. For data
-            with a uniform sampling frequency, for example of one day, the window_length will
-            correspond to a period of time, in this case, 7 days for a window_length of 7.
-        gap (int, optional): The number of rows backward from the target instance before the
-            window of usable data begins. Defaults to 0, which will include the target instance
-            in the window.
-        min_periods (int, optional): Minimum number of observations required for a window to have a value.
+        window_length (int, string, optional): Specifies the amount of data included in each window.
+            If an integer is provided, will correspond to a number of rows. For data with a uniform sampling frequency,
+            for example of one day, the window_length will correspond to a period of time, in this case,
+            7 days for a window_length of 7.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time that each window should span.
+            The list of available offset aliases, can be found at
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases.
+            Defaults to 3.
+        gap (int, string, optional): Specifies a gap backwards from each instance before the
+            window of usable data begins. If an integer is provided, will correspond to a number of rows.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time between a target instance and the beginning of its window.
+            Defaults to 0, which will include the target instance in the window.
+        min_periods (int, optional): Minimum number of observations required for performing calculations
+            over the window. Can only be as large as window_length when window_length is an integer.
+            When window_length is an offset alias string, this limitation does not exist, but care should be taken
+            to not choose a min_periods that will always be larger than the number of observations in a window.
             Defaults to 1.
+
+    Note:
+        Only offset aliases with fixed frequencies can be used when defining gap and window_length.
+        This means that aliases such as `M` or `W` cannot be used, as they can indicate different
+        numbers of days. ('M', because different months are different numbers of days;
+        'W' because week will indicate a certain day of the week, like W-Wed, so that will
+        indicate a different number of days depending on the anchoring date.)
+
+    Note:
+        When using an offset alias to define `gap`, an offset alias must also be used to define `window_length`.
+        This limitation does not exist when using an offset alias to define `window_length`. In fact,
+        if the data has a uniform sampling frequency, it is preferable to use a numeric `gap` as it is more
+        efficient.
+
     Examples:
         >>> import pandas as pd
         >>> rolling_min = RollingMin(window_length=3)
@@ -114,6 +178,14 @@ class RollingMin(TransformPrimitive):
         >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
         >>> rolling_min(times, [4, 3, 2, 1, 0]).tolist()
         [nan, nan, 2.0, 1.0, 0.0]
+
+        We can also set the window_length and gap using offset alias strings.
+
+        >>> import pandas as pd
+        >>> rolling_min = RollingMin(window_length='3min', gap='1min')
+        >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
+        >>> rolling_min(times, [4, 3, 2, 1, 0]).tolist()
+        [nan, 4.0, 3.0, 2.0, 1.0]
     """
     name = "rolling_min"
     input_types = [ColumnSchema(logical_type=Datetime, semantic_tags={'time_index'}), ColumnSchema(semantic_tags={'numeric'})]
@@ -131,6 +203,10 @@ class RollingMin(TransformPrimitive):
                                                   self.window_length,
                                                   gap=self.gap,
                                                   min_periods=self.min_periods)
+
+            if isinstance(self.gap, str):
+                additional_args = (self.gap, min, self.min_periods)
+                return rolled_series.apply(_apply_roll_with_offset_gap, args=additional_args).values
             return rolled_series.min().values
         return rolling_min
 
@@ -147,14 +223,38 @@ class RollingMean(TransformPrimitive):
         Input datetimes should be monotonic.
 
     Args:
-        window_length (int): The number of rows to be included in each frame. For data
-            with a uniform sampling frequency, for example of one day, the window_length will
-            correspond to a period of time, in this case, 7 days for a window_length of 7.
-        gap (int, optional): The number of rows backward from the target instance before the
-            window of usable data begins. Defaults to 0, which will include the target instance
-            in the window.
-        min_periods (int, optional): Minimum number of observations required for a window to have a value.
-            Can only be as large as window_length. Defaults to 1.
+        window_length (int, string, optional): Specifies the amount of data included in each window.
+            If an integer is provided, will correspond to a number of rows. For data with a uniform sampling frequency,
+            for example of one day, the window_length will correspond to a period of time, in this case,
+            7 days for a window_length of 7.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time that each window should span.
+            The list of available offset aliases, can be found at
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases.
+            Defaults to 3.
+        gap (int, string, optional): Specifies a gap backwards from each instance before the
+            window of usable data begins. If an integer is provided, will correspond to a number of rows.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time between a target instance and the beginning of its window.
+            Defaults to 0, which will include the target instance in the window.
+        min_periods (int, optional): Minimum number of observations required for performing calculations
+            over the window. Can only be as large as window_length when window_length is an integer.
+            When window_length is an offset alias string, this limitation does not exist, but care should be taken
+            to not choose a min_periods that will always be larger than the number of observations in a window.
+            Defaults to 1.
+
+    Note:
+        Only offset aliases with fixed frequencies can be used when defining gap and window_length.
+        This means that aliases such as `M` or `W` cannot be used, as they can indicate different
+        numbers of days. ('M', because different months are different numbers of days;
+        'W' because week will indicate a certain day of the week, like W-Wed, so that will
+        indicate a different number of days depending on the anchoring date.)
+
+    Note:
+        When using an offset alias to define `gap`, an offset alias must also be used to define `window_length`.
+        This limitation does not exist when using an offset alias to define `window_length`. In fact,
+        if the data has a uniform sampling frequency, it is preferable to use a numeric `gap` as it is more
+        efficient.
 
     Examples:
         >>> import pandas as pd
@@ -195,6 +295,10 @@ class RollingMean(TransformPrimitive):
                                                   self.window_length,
                                                   gap=self.gap,
                                                   min_periods=self.min_periods)
+
+            if isinstance(self.gap, str):
+                additional_args = (self.gap, np.mean, self.min_periods)
+                return rolled_series.apply(_apply_roll_with_offset_gap, args=additional_args).values
             return rolled_series.mean().values
         return rolling_mean
 
@@ -210,14 +314,38 @@ class RollingSTD(TransformPrimitive):
         (by `window_length` and `gap`). Input datetimes should be monotonic.
 
     Args:
-        window_length (int): The number of rows to be included in each frame. For data
-            with a uniform sampling frequency, for example of one day, the window_length will
-            correspond to a period of time, in this case, 7 days for a window_length of 7.
-        gap (int, optional): The number of rows backward from the target instance before the
-            window of usable data begins. Defaults to 0, which will include the target instance
-            in the window.
-        min_periods (int, optional): Minimum number of observations required for a window to have a value.
-            Can only be as large as window_length. Defaults to 1.
+        window_length (int, string, optional): Specifies the amount of data included in each window.
+            If an integer is provided, will correspond to a number of rows. For data with a uniform sampling frequency,
+            for example of one day, the window_length will correspond to a period of time, in this case,
+            7 days for a window_length of 7.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time that each window should span.
+            The list of available offset aliases, can be found at
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases.
+            Defaults to 3.
+        gap (int, string, optional): Specifies a gap backwards from each instance before the
+            window of usable data begins. If an integer is provided, will correspond to a number of rows.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time between a target instance and the beginning of its window.
+            Defaults to 0, which will include the target instance in the window.
+        min_periods (int, optional): Minimum number of observations required for performing calculations
+            over the window. Can only be as large as window_length when window_length is an integer.
+            When window_length is an offset alias string, this limitation does not exist, but care should be taken
+            to not choose a min_periods that will always be larger than the number of observations in a window.
+            Defaults to 1.
+
+    Note:
+        Only offset aliases with fixed frequencies can be used when defining gap and window_length.
+        This means that aliases such as `M` or `W` cannot be used, as they can indicate different
+        numbers of days. ('M', because different months are different numbers of days;
+        'W' because week will indicate a certain day of the week, like W-Wed, so that will
+        indicate a different number of days depending on the anchoring date.)
+
+    Note:
+        When using an offset alias to define `gap`, an offset alias must also be used to define `window_length`.
+        This limitation does not exist when using an offset alias to define `window_length`. In fact,
+        if the data has a uniform sampling frequency, it is preferable to use a numeric `gap` as it is more
+        efficient.
 
     Examples:
         >>> import pandas as pd
@@ -241,6 +369,13 @@ class RollingSTD(TransformPrimitive):
         >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
         >>> rolling_std(times, [4, 3, 2, 1, 0]).tolist()
         [nan, nan, nan, 1.2909944487358056, 1.2909944487358056]
+
+        We can also set the window_length and gap using offset alias strings.
+        >>> import pandas as pd
+        >>> rolling_std = RollingSTD(window_length='4min', gap='1min')
+        >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
+        >>> rolling_std(times, [4, 3, 2, 1, 0]).tolist()
+        [nan, nan, 0.7071067811865476, 1.0, 1.2909944487358056]
     """
     name = "rolling_std"
     input_types = [ColumnSchema(logical_type=Datetime, semantic_tags={'time_index'}), ColumnSchema(semantic_tags={'numeric'})]
@@ -258,6 +393,13 @@ class RollingSTD(TransformPrimitive):
                                                   self.window_length,
                                                   gap=self.gap,
                                                   min_periods=self.min_periods)
+
+            if isinstance(self.gap, str):
+                def _pandas_std(series):
+                    return series.std()
+                additional_args = (self.gap, _pandas_std, self.min_periods)
+
+                return rolled_series.apply(_apply_roll_with_offset_gap, args=additional_args).values
             return rolled_series.std().values
         return rolling_std
 
@@ -273,14 +415,38 @@ class RollingCount(TransformPrimitive):
         Input datetimes should be monotonic.
 
     Args:
-        window_length (int): The number of rows to be included in each frame. For data
-            with a uniform sampling frequency, for example of one day, the window_length will
-            correspond to a period of time, in this case, 7 days for a window_length of 7.
-        gap (int, optional): The number of rows backward from the target instance before the
-            window of usable data begins. Defaults to 0, which will include the target instance
-            in the window.
-        min_periods (int, optional): Minimum number of observations required for a window to have a value.
-            Can only be as large as window_length. Defaults to 1.
+        window_length (int, string, optional): Specifies the amount of data included in each window.
+            If an integer is provided, will correspond to a number of rows. For data with a uniform sampling frequency,
+            for example of one day, the window_length will correspond to a period of time, in this case,
+            7 days for a window_length of 7.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time that each window should span.
+            The list of available offset aliases, can be found at
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases.
+            Defaults to 3.
+        gap (int, string, optional): Specifies a gap backwards from each instance before the
+            window of usable data begins. If an integer is provided, will correspond to a number of rows.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time between a target instance and the beginning of its window.
+            Defaults to 0, which will include the target instance in the window.
+        min_periods (int, optional): Minimum number of observations required for performing calculations
+            over the window. Can only be as large as window_length when window_length is an integer.
+            When window_length is an offset alias string, this limitation does not exist, but care should be taken
+            to not choose a min_periods that will always be larger than the number of observations in a window.
+            Defaults to 1.
+
+    Note:
+        Only offset aliases with fixed frequencies can be used when defining gap and h.
+        This means that aliases such as `M` or `W` cannot be used, as they can indicate different
+        numbers of days. ('M', because different months are different numbers of days;
+        'W' because week will indicate a certain day of the week, like W-Wed, so that will
+        indicate a different number of days depending on the anchoring date.)
+
+    Note:
+        When using an offset alias to define `gap`, an offset alias must also be used to define `window_length`.
+        This limitation does not exist when using an offset alias to define `window_length`. In fact,
+        if the data has a uniform sampling frequency, it is preferable to use a numeric `gap` as it is more
+        efficient.
 
     Examples:
         >>> import pandas as pd
@@ -304,6 +470,14 @@ class RollingCount(TransformPrimitive):
         >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
         >>> rolling_count(times).tolist()
         [nan, nan, 3.0, 3.0, 3.0]
+
+        We can also set the window_length and gap using offset alias strings.
+        >>> import pandas as pd
+        >>> rolling_count = RollingCount(window_length='3min', gap='1min')
+        >>> times = pd.date_range(start='2019-01-01', freq='1min', periods=5)
+        >>> rolling_count(times).tolist()
+        [nan, 1.0, 2.0, 3.0, 3.0]
+
     """
     name = "rolling_count"
     input_types = [ColumnSchema(logical_type=Datetime, semantic_tags={'time_index'})]
@@ -321,7 +495,15 @@ class RollingCount(TransformPrimitive):
                                                   self.window_length,
                                                   gap=self.gap,
                                                   min_periods=self.min_periods)
+
+            if isinstance(self.gap, str):
+                # Since _apply_roll_with_offset_gap doesn't artificially add nans before rolling,
+                # it produces correct results
+                additional_args = (self.gap, len, self.min_periods)
+                return rolled_series.apply(_apply_roll_with_offset_gap, args=additional_args).values
+
             rolling_count_series = rolled_series.count()
+
             # The shift made to account for gap adds NaNs to the rolled series
             # Those values get counted towards min_periods when they shouldn't.
             # So we need to replace any of those partial values with NaNs

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -5,6 +5,7 @@ from inspect import isclass
 import holidays
 import numpy as np
 import pandas as pd
+from pandas.tseries.frequencies import to_offset
 
 import featuretools
 from featuretools.primitives.base import (
@@ -232,20 +233,31 @@ class PrimitivesDeserializer(object):
 
 
 def _roll_series_with_gap(series, window_size, gap=0, min_periods=1):
-    """Provide rolling window calculations with window specified with both a window length
-        and a gap that indicates the amount of time between each instance and its window.
+    """Provide rolling window calculations where the windows are determined using both a gap parameter
+    that indicates the amount of time between each instance and its window and a window length parameter
+    that determines the amount of data in each window.
 
     Args:
-        series (Series): The series over which the windows will be created. Must be numeric in nature
-            and have a datetime64[ns] index.
-        window_length (int): The number of rows to be included in each window. For data
-            with a uniform sampling frequency, for example of one day, the window_length will
-            correspond to a period of time, in this case, 7 days for a window_length of 7.
-        gap (int, optional): The number of rows backward from the target instance before the
-            window of usable data begins. Defaults to 0, which will include the target instance
-            in the window.
+        series (Series): The series over which rolling windows will be created. Must be numeric in nature
+            and have a DatetimeIndex.
+        window_size (int, string): Specifies the amount of data included in each window.
+            If an integer is provided, will correspond to a number of rows. For data with a uniform sampling frequency,
+            for example of one day, the window_length will correspond to a period of time, in this case,
+            7 days for a window_length of 7.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time that each window should span.
+            The list of available offset aliases, can be found at
+            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
+        gap (int, string, optional): Specifies a gap backwards from each instance before the
+            window of usable data begins. If an integer is provided, will correspond to a number of rows.
+            If a string is provided, it must be one of pandas' offset alias strings ('1D', '1H', etc),
+            and it will indicate a length of time between a target instance and the beginning of its window.
+            Defaults to 0, which will include the target instance in the window.
         min_periods (int, optional): Minimum number of observations required for performing calculations
-            over the window. Can only be as large as window_length. Defaults to 1.
+            over the window. Can only be as large as window_length when window_length is an integer.
+            When window_length is an offset alias string, this limitation does not exist, but care should be taken
+            to not choose a min_periods that will always be larger than the number of observations in a window.
+            Defaults to 1.
 
     Returns:
         pandas.core.window.rolling.Rolling: The Rolling object for the series passed in.
@@ -262,17 +274,129 @@ def _roll_series_with_gap(series, window_size, gap=0, min_periods=1):
         we handle this case manually, replacing those values with NaNs. Any primitive that uses this function
         should determine whether this kind of handling is also necessary.
 
+    Note:
+        Only offset aliases with fixed frequencies can be used when defining gap and window_length.
+        This means that aliases such as `M` or `W` cannot be used, as they can indicate different
+        numbers of days. ('M', because different months are different numbers of days;
+        'W' because week will indicate a certain day of the week, like W-Wed, so that will
+        indicate a different number of days depending on the anchoring date.)
+
+    Note:
+        When using an offset alias to define `gap`, an offset alias must also be used to define `window_size`.
+        This limitation does not exist when using an offset alias to define `window_size`. In fact,
+        if the data has a uniform sampling frequency, it is preferable to use a numeric `gap` as it is more
+        efficient.
+
     """
+    _check_window_size(window_size)
+    _check_gap(window_size, gap)
+
     # Workaround for pandas' bug: https://github.com/pandas-dev/pandas/issues/43016
     # Can remove when upgraded to pandas 1.4.0
     if str(series.dtype) == 'Int64':
         series = series.astype('float64')
 
-    gap_applied = series
-    if gap > 0:
-        gap_applied = series.shift(gap)
+    functional_window_length = window_size
+    if isinstance(gap, str):
+        # Add the window_size and gap so that the rolling operation correctly takes gap into account.
+        # That way, we can later remove the gap rows in order to apply the primitive function
+        # to the correct window
+        functional_window_length = to_offset(window_size) + to_offset(gap)
+    elif gap > 0:
+        # When gap is numeric, we can apply a shift to incorporate gap right now
+        # since the gap will be the same number of rows for the whole dataset
+        series = series.shift(gap)
 
-    return gap_applied.rolling(window_size, min_periods)
+    return series.rolling(functional_window_length, min_periods)
+
+
+def _get_rolled_series_without_gap(window, gap_offset):
+    """Applies the gap offset_string to the rolled window, returning a window
+    that is the correct length of time away from the original instance.
+
+     Args:
+        window (Series): A rolling window that includes both the window length and gap spans of time.
+        gap_offset (string): The pandas offset alias that determines how much time at the end of the window
+            should be removed.
+
+    Returns:
+        Series: The window with gap rows removed
+    """
+    if not len(window):
+        return window
+
+    window_start_date = window.index[0]
+    window_end_date = window.index[-1]
+
+    gap_bound = window_end_date - to_offset(gap_offset)
+
+    # If the gap is larger than the series, no rows are left in the window
+    if gap_bound < window_start_date:
+        return pd.Series()
+
+    # Only return the rows that are within the offset's bounds
+    return window[window.index <= gap_bound]
+
+
+def _apply_roll_with_offset_gap(window, gap_offset, reducer_fn, min_periods):
+    """Takes in a series to which an offset gap will be applied, removing however many
+    rows fall under the gap before applying the reducing function.
+
+    Args:
+        window (Series):  A rolling window that includes both the window length and gap spans of time.
+        gap_offset (string): The pandas offset alias that determines how much time at the end of the window
+            should be removed.
+        reducer_fn (callable[Series -> float]): The function to be applied to the window in order to produce
+            the aggregate that will be included in the resulting feature.
+        min_periods (int): Minimum number of observations required for performing calculations
+            over the window.
+
+    Returns:
+        float: The aggregate value to be used as a feature value.
+    """
+    window = _get_rolled_series_without_gap(window, gap_offset)
+
+    if min_periods is None:
+        min_periods = 1
+
+    if len(window) < min_periods or not len(window):
+        return np.nan
+
+    return reducer_fn(window)
+
+
+def _check_window_size(window_size):
+    # Window length must either be a valid offset alias
+    if isinstance(window_size, str):
+        try:
+            to_offset(window_size)
+        except ValueError:
+            raise ValueError(f"Cannot roll series. The specified window length, {window_size}, is not a valid offset alias.")
+    # Or an integer greater than zero
+    elif isinstance(window_size, int):
+        if window_size <= 0:
+            raise ValueError("Window length must be greater than zero.")
+    else:
+        raise TypeError("Window length must be either an offset string or an integer.")
+
+
+def _check_gap(window_size, gap):
+    # Gap must either be a valid offset string that also has an offset string window length
+    if isinstance(gap, str):
+        if not isinstance(window_size, str):
+            raise TypeError(f"Cannot roll series with offset gap, {gap}, and numeric window length, {window_size}. "
+                            "If an offset alias is used for gap, the window length must also be defined as an offset alias. "
+                            "Please either change gap to be numeric or change window length to be an offset alias.")
+        try:
+            to_offset(gap)
+        except ValueError:
+            raise ValueError(f"Cannot roll series. The specified gap, {gap}, is not a valid offset alias.")
+    # Or an integer greater than or equal to zero
+    elif isinstance(gap, int):
+        if gap < 0:
+            raise ValueError("Gap must be greater than or equal to zero.")
+    else:
+        raise TypeError("Gap must be either an offset string or an integer.")
 
 
 def _deconstrct_latlongs(latlongs):

--- a/featuretools/tests/primitive_tests/test_primitive_utils.py
+++ b/featuretools/tests/primitive_tests/test_primitive_utils.py
@@ -33,12 +33,15 @@ from featuretools.primitives import (
 )
 from featuretools.primitives.base import PrimitiveBase
 from featuretools.primitives.utils import (
+    _apply_roll_with_offset_gap,
     _get_descriptions,
+    _get_rolled_series_without_gap,
     _get_unique_input_types,
     _roll_series_with_gap,
     list_primitive_files,
     load_primitive_from_file
 )
+from featuretools.tests.primitive_tests.utils import get_number_from_offset
 from featuretools.utils.gen_utils import Library
 
 
@@ -140,12 +143,45 @@ def test_errors_no_primitive_in_file(bad_primitives_files_dir):
     assert str(excinfo.value) == error_text
 
 
+def test_get_rolled_series_without_gap(rolling_series_pd):
+    # Data is daily, so number of rows should be number of days not included in the gap
+    assert len(_get_rolled_series_without_gap(rolling_series_pd, "11D")) == 9
+    assert len(_get_rolled_series_without_gap(rolling_series_pd, "0D")) == 20
+    assert len(_get_rolled_series_without_gap(rolling_series_pd, "48H")) == 18
+    assert len(_get_rolled_series_without_gap(rolling_series_pd, "4H")) == 19
+
+
+def test_get_rolled_series_without_gap_not_uniform(rolling_series_pd):
+    non_uniform_series = rolling_series_pd.iloc[[0, 2, 5, 6, 8, 9]]
+
+    assert len(_get_rolled_series_without_gap(non_uniform_series, "10D")) == 0
+    assert len(_get_rolled_series_without_gap(non_uniform_series, "0D")) == 6
+    assert len(_get_rolled_series_without_gap(non_uniform_series, "48H")) == 4
+    assert len(_get_rolled_series_without_gap(non_uniform_series, "4H")) == 5
+    assert len(_get_rolled_series_without_gap(non_uniform_series, "4D")) == 3
+    assert len(_get_rolled_series_without_gap(non_uniform_series, "4D2H")) == 2
+
+
+def test_get_rolled_series_without_gap_empty_series(rolling_series_pd):
+    empty_series = pd.Series()
+    assert len(_get_rolled_series_without_gap(empty_series, "1D")) == 0
+    assert len(_get_rolled_series_without_gap(empty_series, "0D")) == 0
+
+
+def test_get_rolled_series_without_gap_large_bound(rolling_series_pd):
+    assert len(_get_rolled_series_without_gap(rolling_series_pd, "100D")) == 0
+    assert len(_get_rolled_series_without_gap(rolling_series_pd.iloc[[0, 2, 5, 6, 8, 9]], "20D")) == 0
+
+
 @pytest.mark.parametrize(
     "window_length, gap",
     [
         (3, 2),
         (3, 4),  # gap larger than window
         (2, 0),  # gap explicitly set to 0
+        ('3d', '2d'),  # using offset aliases
+        ('3d', '4d'),
+        ('4d', '0d'),
     ],
 )
 def test_roll_series_with_gap(window_length, gap, rolling_series_pd):
@@ -155,9 +191,17 @@ def test_roll_series_with_gap(window_length, gap, rolling_series_pd):
     assert len(rolling_max) == len(rolling_series_pd)
     assert len(rolling_min) == len(rolling_series_pd)
 
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
     for i in range(len(rolling_series_pd)):
-        start_idx = i - gap - window_length + 1
-        end_idx = i - gap
+        start_idx = i - gap_num - window_length_num + 1
+
+        if isinstance(gap, str):
+            # No gap functionality is happening, so gap isn't taken account in the end index
+            # it's like the gap is 0; it includes the row itself
+            end_idx = i
+        else:
+            end_idx = i - gap_num
 
         # If start and end are negative, they're entirely before
         if start_idx < 0 and end_idx < 0:
@@ -174,10 +218,9 @@ def test_roll_series_with_gap(window_length, gap, rolling_series_pd):
         assert rolling_max.iloc[i] == end_idx
 
 
-def test_roll_series_with_no_gap(rolling_series_pd):
-    window_length = 3
-    gap = 0
-    actual_rolling = _roll_series_with_gap(rolling_series_pd, window_length, gap=gap).mean()
+@pytest.mark.parametrize("window_length", [3, "3d"])
+def test_roll_series_with_no_gap(window_length, rolling_series_pd):
+    actual_rolling = _roll_series_with_gap(rolling_series_pd, window_length).mean()
     expected_rolling = rolling_series_pd.rolling(window_length, min_periods=1).mean()
 
     pd.testing.assert_series_equal(actual_rolling, expected_rolling)
@@ -187,10 +230,15 @@ def test_roll_series_with_no_gap(rolling_series_pd):
     "window_length, gap",
     [
         (6, 2),
-        (6, 0)  # No gap - changes early values
+        (6, 0),  # No gap - changes early values
+        ('6d', '0d'),  # Uses offset aliases
+        ('6d', '2d')
     ]
 )
 def test_roll_series_with_gap_early_values(window_length, gap, rolling_series_pd):
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
+
     # Default min periods is 1 - will include all
     default_partial_values = _roll_series_with_gap(rolling_series_pd,
                                                    window_length,
@@ -198,24 +246,33 @@ def test_roll_series_with_gap_early_values(window_length, gap, rolling_series_pd
     num_empty_aggregates = len(default_partial_values.loc[default_partial_values == 0])
     num_partial_aggregates = len((default_partial_values
                                   .loc[default_partial_values != 0])
-                                 .loc[default_partial_values < window_length])
-    assert num_empty_aggregates == gap
-    assert num_partial_aggregates == window_length - 1
+                                 .loc[default_partial_values < window_length_num])
+
+    assert num_partial_aggregates == window_length_num - 1
+    if isinstance(gap, str):
+        # gap isn't handled, so we'll always at least include the row itself
+        assert num_empty_aggregates == 0
+    else:
+        assert num_empty_aggregates == gap_num
 
     # Make min periods the size of the window
     no_partial_values = _roll_series_with_gap(rolling_series_pd,
                                               window_length,
                                               gap=gap,
-                                              min_periods=window_length).count()
+                                              min_periods=window_length_num).count()
     num_null_aggregates = len(no_partial_values.loc[pd.isna(no_partial_values)])
-    num_partial_aggregates = len(no_partial_values.loc[no_partial_values < window_length])
+    num_partial_aggregates = len(no_partial_values.loc[no_partial_values < window_length_num])
 
     # because we shift, gap is included as nan values in the series.
     # Count treats nans in a window as values that don't get counted,
     # so the gap rows get included in the count for whether a window has "min periods".
     # This is different than max, for example, which does not count nans in a window as values towards "min periods"
-    assert num_null_aggregates == window_length - 1
-    assert num_partial_aggregates == gap
+    assert num_null_aggregates == window_length_num - 1
+    if isinstance(gap, str):
+        # gap isn't handled, so we'll never have any partial aggregates
+        assert num_partial_aggregates == 0
+    else:
+        assert num_partial_aggregates == gap_num
 
 
 def test_roll_series_with_gap_nullable_types(rolling_series_pd):
@@ -252,3 +309,267 @@ def test_roll_series_with_gap_nullable_types_with_nans(rolling_series_pd):
             assert pd.isnull(expected)
         else:
             assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        ('3d', '2d'),
+        ('3d', '4d'),
+        ('4d', '0d'),
+    ],
+)
+def test_apply_roll_with_offset_gap(window_length, gap, rolling_series_pd):
+    def max_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, max, min_periods=1)
+
+    rolling_max_obj = _roll_series_with_gap(rolling_series_pd, window_length, gap=gap)
+    rolling_max_series = rolling_max_obj.apply(max_wrapper)
+
+    def min_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, min, min_periods=1)
+
+    rolling_min_obj = _roll_series_with_gap(rolling_series_pd, window_length, gap=gap)
+    rolling_min_series = rolling_min_obj.apply(min_wrapper)
+
+    assert len(rolling_max_series) == len(rolling_series_pd)
+    assert len(rolling_min_series) == len(rolling_series_pd)
+
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
+    for i in range(len(rolling_series_pd)):
+        start_idx = i - gap_num - window_length_num + 1
+        # Now that we have the _apply call, this acts as expected
+        end_idx = i - gap_num
+
+        # If start and end are negative, they're entirely before
+        if start_idx < 0 and end_idx < 0:
+            assert pd.isnull(rolling_max_series.iloc[i])
+            assert pd.isnull(rolling_min_series.iloc[i])
+            continue
+
+        if start_idx < 0:
+            start_idx = 0
+
+        # Because the row values are a range from 0 to 20, the rolling min will be the start index
+        # and the rolling max will be the end idx
+        assert rolling_min_series.iloc[i] == start_idx
+        assert rolling_max_series.iloc[i] == end_idx
+
+
+@pytest.mark.parametrize(
+    "min_periods",
+    [1, 0, None],
+)
+def test_apply_roll_with_offset_gap_default_min_periods(min_periods, rolling_series_pd):
+    window_length = '5d'
+    window_length_num = 5
+    gap = '3d'
+    gap_num = 3
+
+    def count_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, len, min_periods=min_periods)
+
+    rolling_count_obj = _roll_series_with_gap(rolling_series_pd, window_length, gap=gap)
+    rolling_count_series = rolling_count_obj.apply(count_wrapper)
+
+    # gap essentially creates a rolling series that has no elements; which should be nan
+    # to differentiate from when a window only has null values
+    num_empty_aggregates = rolling_count_series.isna().sum()
+    num_partial_aggregates = len((rolling_count_series
+                                  .loc[rolling_count_series != 0])
+                                 .loc[rolling_count_series < window_length_num])
+
+    assert num_empty_aggregates == gap_num
+    assert num_partial_aggregates == window_length_num - 1
+
+
+@pytest.mark.parametrize(
+    "min_periods",
+    [2, 3, 4, 5],
+)
+def test_apply_roll_with_offset_gap_min_periods(min_periods, rolling_series_pd):
+    window_length = '5d'
+    window_length_num = 5
+    gap = '3d'
+    gap_num = 3
+
+    def count_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, len, min_periods=min_periods)
+
+    rolling_count_obj = _roll_series_with_gap(rolling_series_pd, window_length, gap=gap)
+    rolling_count_series = rolling_count_obj.apply(count_wrapper)
+
+    # gap essentially creates rolling series that have no elements; which should be nan
+    # to differentiate from when a window only has null values
+    num_empty_aggregates = rolling_count_series.isna().sum()
+    num_partial_aggregates = len((rolling_count_series
+                                  .loc[rolling_count_series != 0])
+                                 .loc[rolling_count_series < window_length_num])
+
+    assert num_empty_aggregates == min_periods - 1 + gap_num
+    assert num_partial_aggregates == window_length_num - min_periods
+
+
+def test_apply_roll_with_offset_gap_non_uniform():
+    window_length = '3d'
+    gap = '3d'
+    # When the data isn't uniform, this impacts the number of values in each rolling window
+    datetimes = (list(pd.date_range(start='2017-01-01', freq='1d', periods=7)) +
+                 list(pd.date_range(start='2017-02-01', freq='2d', periods=7)) +
+                 list(pd.date_range(start='2017-03-01', freq='1d', periods=7)))
+    no_freq_series = pd.Series(range(len(datetimes)), index=datetimes)
+
+    assert pd.infer_freq(no_freq_series.index) is None
+
+    expected_series = pd.Series([None, None, None, 1, 2, 3, 3] +
+                                [None, None, 1, 1, 1, 1, 1] +
+                                [None, None, None, 1, 2, 3, 3], index=datetimes)
+
+    def count_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, len, min_periods=1)
+    rolling_count_obj = _roll_series_with_gap(no_freq_series, window_length, gap=gap)
+    rolling_count_series = rolling_count_obj.apply(count_wrapper)
+
+    pd.testing.assert_series_equal(rolling_count_series, expected_series)
+
+
+def test_apply_roll_with_offset_data_frequency_higher_than_parameters_frequency():
+    window_length = '5D'  # 120 hours
+    window_length_num = 5
+    # In order for min periods to be the length of the window, we multiply 24hours*5
+    min_periods = window_length_num * 24
+
+    datetimes = list(pd.date_range(start='2017-01-01', freq='1H', periods=200))
+    high_frequency_series = pd.Series(range(200), index=datetimes)
+
+    # Check without gap
+    gap = "0d"
+    gap_num = 0
+
+    def max_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, max, min_periods=min_periods)
+    rolling_max_obj = _roll_series_with_gap(high_frequency_series, window_length, min_periods=min_periods, gap=gap)
+    rolling_max_series = rolling_max_obj.apply(max_wrapper)
+
+    assert rolling_max_series.isna().sum() == (min_periods - 1) + gap_num
+
+    # Check with small gap
+    gap = '3H'
+    gap_num = 3
+
+    def max_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, max, min_periods=min_periods)
+    rolling_max_obj = _roll_series_with_gap(high_frequency_series, window_length, min_periods=min_periods, gap=gap)
+    rolling_max_series = rolling_max_obj.apply(max_wrapper)
+
+    assert rolling_max_series.isna().sum() == (min_periods - 1) + gap_num
+
+    # Check with large gap - in terms of days, so we'll multiply by 24hours for number of nans
+    gap = '2D'
+    gap_num = 2
+
+    def max_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, max, min_periods=min_periods)
+    rolling_max_obj = _roll_series_with_gap(high_frequency_series, window_length, min_periods=min_periods, gap=gap)
+    rolling_max_series = rolling_max_obj.apply(max_wrapper)
+
+    assert rolling_max_series.isna().sum() == (min_periods - 1) + (gap_num * 24)
+
+
+def test_apply_roll_with_offset_data_min_periods_too_big(rolling_series_pd):
+    window_length = '5D'
+    gap = "2d"
+
+    # Since the data has a daily frequency, there will only be, at most, 5 rows in the window
+    min_periods = 6
+
+    def max_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, gap, max, min_periods=min_periods)
+    rolling_max_obj = _roll_series_with_gap(rolling_series_pd, window_length, min_periods=min_periods, gap=gap)
+    rolling_max_series = rolling_max_obj.apply(max_wrapper)
+
+    # The resulting series is comprised entirely of nans
+    assert rolling_max_series.isna().sum() == len(rolling_series_pd)
+
+
+def test_roll_series_with_gap_different_input_types_same_result_uniform(rolling_series_pd):
+    # Offset inputs will only produce the same results as numeric inputs
+    # when the data has a uniform frequency
+    offset_gap = '2d'
+    offset_window_length = '5d'
+    int_gap = 2
+    int_window_length = 5
+
+    # Rolling series' with matching input types
+    expected_rolling_numeric = _roll_series_with_gap(rolling_series_pd,
+                                                     window_size=int_window_length,
+                                                     gap=int_gap).max()
+
+    def count_wrapper(sub_s):
+        return _apply_roll_with_offset_gap(sub_s, offset_gap, max, min_periods=1)
+    rolling_count_obj = _roll_series_with_gap(rolling_series_pd,
+                                              window_size=offset_window_length,
+                                              gap=offset_gap)
+    expected_rolling_offset = rolling_count_obj.apply(count_wrapper)
+
+    # confirm that the offset and gap results are equal to one another
+    pd.testing.assert_series_equal(expected_rolling_numeric, expected_rolling_offset)
+
+    # Rolling series' with mismatched input types
+    mismatched_numeric_gap = _roll_series_with_gap(rolling_series_pd,
+                                                   window_size=offset_window_length,
+                                                   gap=int_gap).max()
+    # Confirm the mismatched results also produce the same results
+    pd.testing.assert_series_equal(expected_rolling_numeric, mismatched_numeric_gap)
+
+
+def test_roll_series_with_gap_incorrect_types(rolling_series_pd):
+    error = "Window length must be either an offset string or an integer."
+    with pytest.raises(TypeError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size=4.2,
+                              gap=4)
+
+    error = "Gap must be either an offset string or an integer."
+    with pytest.raises(TypeError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size=4,
+                              gap=4.2)
+
+
+def test_roll_series_with_gap_negative_inputs(rolling_series_pd):
+    error = "Window length must be greater than zero."
+    with pytest.raises(ValueError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size=-4,
+                              gap=4)
+
+    error = "Gap must be greater than or equal to zero."
+    with pytest.raises(ValueError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size=4,
+                              gap=-4)
+
+
+def test_roll_series_with_non_offset_string_inputs(rolling_series_pd):
+    error = "Cannot roll series. The specified gap, test, is not a valid offset alias."
+    with pytest.raises(ValueError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size='4D',
+                              gap='test')
+
+    error = "Cannot roll series. The specified window length, test, is not a valid offset alias."
+    with pytest.raises(ValueError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size='test',
+                              gap='7D')
+
+    # Test mismatched types error
+    error = ("Cannot roll series with offset gap, 2d, and numeric window length, 7. "
+             "If an offset alias is used for gap, the window length must also be defined as an offset alias. "
+             "Please either change gap to be numeric or change window length to be an offset alias.")
+    with pytest.raises(TypeError, match=error):
+        _roll_series_with_gap(rolling_series_pd,
+                              window_size=7,
+                              gap='2d').max()

--- a/featuretools/tests/primitive_tests/test_rolling_primitive.py
+++ b/featuretools/tests/primitive_tests/test_rolling_primitive.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 
@@ -9,95 +11,177 @@ from featuretools.primitives import (
     RollingSTD
 )
 from featuretools.primitives.utils import _roll_series_with_gap
+from featuretools.tests.primitive_tests.utils import get_number_from_offset
 
 
-def test_rolling_max(rolling_series_pd):
-    window_length = 5
-    gap = 2
-
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (5, 2),
+        (5, 0),
+        ('5d', '7d'),
+        ('5d', '0d'),
+    ]
+)
+@pytest.mark.parametrize(
+    "min_periods",
+    [1, 0, 2, 5]
+)
+def test_rolling_max(min_periods, window_length, gap, rolling_series_pd):
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
+    # Since we're using a uniform series we can check correctness using numeric parameters
     expected_vals = _roll_series_with_gap(rolling_series_pd,
-                                          window_length,
-                                          gap=gap,
-                                          min_periods=window_length).max().values
+                                          window_length_num,
+                                          gap=gap_num,
+                                          min_periods=min_periods).max().values
 
-    primitive_instance = RollingMax(window_length=window_length, gap=gap, min_periods=window_length)
+    primitive_instance = RollingMax(window_length=window_length, gap=gap, min_periods=min_periods)
     primitive_func = primitive_instance.get_function()
 
     actual_vals = pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
 
-    assert actual_vals.isna().sum() == gap + window_length - 1
+    # Since min_periods of 0 is the same as min_periods of 1
+    num_nans_from_min_periods = min_periods or 1
+
+    assert actual_vals.isna().sum() == gap_num + num_nans_from_min_periods - 1
     pd.testing.assert_series_equal(pd.Series(expected_vals), actual_vals)
 
 
-def test_rolling_min(rolling_series_pd):
-    window_length = 5
-    gap = 2
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (5, 2),
+        (5, 0),
+        ('5d', '7d'),
+        ('5d', '0d'),
+    ]
+)
+@pytest.mark.parametrize(
+    "min_periods",
+    [1, 0, 2, 5]
+)
+def test_rolling_min(min_periods, window_length, gap, rolling_series_pd):
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
 
+    # Since we're using a uniform series we can check correctness using numeric parameters
     expected_vals = _roll_series_with_gap(rolling_series_pd,
-                                          window_length,
-                                          gap=gap,
-                                          min_periods=window_length).min().values
+                                          window_length_num,
+                                          gap=gap_num,
+                                          min_periods=min_periods).min().values
 
-    primitive_instance = RollingMin(window_length=window_length, gap=gap, min_periods=window_length)
+    primitive_instance = RollingMin(window_length=window_length, gap=gap, min_periods=min_periods)
     primitive_func = primitive_instance.get_function()
 
     actual_vals = pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
 
-    assert actual_vals.isna().sum() == gap + window_length - 1
+    # Since min_periods of 0 is the same as min_periods of 1
+    num_nans_from_min_periods = min_periods or 1
+
+    assert actual_vals.isna().sum() == gap_num + num_nans_from_min_periods - 1
     pd.testing.assert_series_equal(pd.Series(expected_vals), actual_vals)
 
 
-def test_rolling_mean(rolling_series_pd):
-    window_length = 5
-    gap = 2
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (5, 2),
+        (5, 0),
+        ('5d', '7d'),
+        ('5d', '0d'),
+    ]
+)
+@pytest.mark.parametrize(
+    "min_periods",
+    [1, 0, 2, 5]
+)
+def test_rolling_mean(min_periods, window_length, gap, rolling_series_pd):
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
 
+    # Since we're using a uniform series we can check correctness using numeric parameters
     expected_vals = _roll_series_with_gap(rolling_series_pd,
-                                          window_length,
-                                          gap=gap,
-                                          min_periods=window_length).mean().values
+                                          window_length_num,
+                                          gap=gap_num,
+                                          min_periods=min_periods).mean().values
 
-    primitive_instance = RollingMean(window_length=window_length, gap=gap, min_periods=window_length)
+    primitive_instance = RollingMean(window_length=window_length, gap=gap, min_periods=min_periods)
     primitive_func = primitive_instance.get_function()
 
     actual_vals = pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
 
-    assert actual_vals.isna().sum() == gap + window_length - 1
+    # Since min_periods of 0 is the same as min_periods of 1
+    num_nans_from_min_periods = min_periods or 1
+
+    assert actual_vals.isna().sum() == gap_num + num_nans_from_min_periods - 1
     pd.testing.assert_series_equal(pd.Series(expected_vals), actual_vals)
 
 
-def test_rolling_std(rolling_series_pd):
-    window_length = 5
-    gap = 2
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (5, 2),
+        (5, 0),
+        ('5d', '7d'),
+        ('5d', '0d'),
+    ]
+)
+@pytest.mark.parametrize(
+    "min_periods",
+    [1, 0, 2, 5]
+)
+def test_rolling_std(min_periods, window_length, gap, rolling_series_pd):
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
 
+    # Since we're using a uniform series we can check correctness using numeric parameters
     expected_vals = _roll_series_with_gap(rolling_series_pd,
-                                          window_length,
-                                          gap=gap,
-                                          min_periods=window_length).std().values
+                                          window_length_num,
+                                          gap=gap_num,
+                                          min_periods=min_periods).std().values
 
-    primitive_instance = RollingSTD(window_length=window_length, gap=gap, min_periods=window_length)
+    primitive_instance = RollingSTD(window_length=window_length, gap=gap, min_periods=min_periods)
     primitive_func = primitive_instance.get_function()
 
     actual_vals = pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
 
-    assert actual_vals.isna().sum() == gap + window_length - 1
+    # Since min_periods of 0 is the same as min_periods of 1
+    num_nans_from_min_periods = min_periods or 2
+
+    if min_periods in [0, 1]:
+        # the additional nan is because std pandas function returns NaN if there's only one value
+        num_nans = gap_num + 1
+    else:
+        num_nans = gap_num + num_nans_from_min_periods - 1
+
+    # The extra 1 at the beinning is because the std pandas function returns NaN if there's only one value
+    assert actual_vals.isna().sum() == num_nans
     pd.testing.assert_series_equal(pd.Series(expected_vals), actual_vals)
 
 
-def test_rolling_count(rolling_series_pd):
-    window_length = 5
-    gap = 2
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (5, 2),
+        ('6d', '7d'),
+    ]
+)
+def test_rolling_count(window_length, gap, rolling_series_pd):
+    gap_num = get_number_from_offset(gap)
+    window_length_num = get_number_from_offset(window_length)
 
     expected_vals = _roll_series_with_gap(rolling_series_pd,
-                                          window_length,
-                                          gap=gap,
-                                          min_periods=window_length).count().values
+                                          window_length_num,
+                                          gap=gap_num,
+                                          min_periods=window_length_num).count().values
 
-    primitive_instance = RollingCount(window_length=window_length, gap=gap, min_periods=window_length)
+    primitive_instance = RollingCount(window_length=window_length, gap=gap, min_periods=window_length_num)
     primitive_func = primitive_instance.get_function()
 
     actual_vals = pd.Series(primitive_func(rolling_series_pd.index))
 
-    num_nans = gap + window_length - 1
+    num_nans = gap_num + window_length_num - 1
     assert actual_vals.isna().sum() == num_nans
     # RollingCount will not match the exact _roll_series_with_gap call,
     # because it handles the min_periods difference within the primitive
@@ -113,10 +197,8 @@ def test_rolling_count(rolling_series_pd):
         (5, 6)
     ]
 )
-def test_rolling_count_primitive_min_periods_nans(min_periods, expected_num_nams, rolling_series_pd):
-    window_length = 5
-    gap = 2
-
+@pytest.mark.parametrize("window_length, gap", [('5d', '2d'), (5, 2)])
+def test_rolling_count_primitive_min_periods_nans(window_length, gap, min_periods, expected_num_nams, rolling_series_pd):
     primitive_instance = RollingCount(window_length=window_length, gap=gap, min_periods=min_periods)
     primitive_func = primitive_instance.get_function()
     vals = pd.Series(primitive_func(rolling_series_pd.index))
@@ -133,12 +215,93 @@ def test_rolling_count_primitive_min_periods_nans(min_periods, expected_num_nams
         (5, 4)
     ]
 )
-def test_rolling_count_with_no_gap(min_periods, expected_num_nams, rolling_series_pd):
-    window_length = 5
-    gap = 0
-
+@pytest.mark.parametrize("window_length, gap", [('5d', '0d'), (5, 0)])
+def test_rolling_count_with_no_gap(window_length, gap, min_periods, expected_num_nams, rolling_series_pd):
     primitive_instance = RollingCount(window_length=window_length, gap=gap, min_periods=min_periods)
     primitive_func = primitive_instance.get_function()
     vals = pd.Series(primitive_func(rolling_series_pd.index))
 
     assert vals.isna().sum() == expected_num_nams
+
+
+@pytest.mark.parametrize("primitive", [RollingCount, RollingMax, RollingMin, RollingMean])
+def test_rolling_primitives_non_uniform(primitive):
+    # When the data isn't uniform, this impacts the number of values in each rolling window
+    datetimes = (list(pd.date_range(start='2017-01-01', freq='1d', periods=3)) +
+                 list(pd.date_range(start='2017-01-10', freq='2d', periods=4)) +
+                 list(pd.date_range(start='2017-01-22', freq='1d', periods=7)))
+    no_freq_series = pd.Series(range(len(datetimes)), index=datetimes)
+
+    # Should match RollingCount exactly and have same nan values as other primitives
+    expected_series = pd.Series([None, 1, 2] +
+                                [None, 1, 1, 1] +
+                                [None, 1, 2, 3, 3, 3, 3])
+
+    primitive_instance = primitive(window_length='3d', gap='1d')
+    if isinstance(primitive_instance, RollingCount):
+        rolled_series = pd.Series(primitive_instance(no_freq_series.index))
+        pd.testing.assert_series_equal(rolled_series, expected_series)
+    else:
+        rolled_series = pd.Series(primitive_instance(no_freq_series.index, pd.Series(no_freq_series.values)))
+        pd.testing.assert_series_equal(expected_series.isna(), rolled_series.isna())
+
+
+def test_rolling_std_non_uniform():
+    # When the data isn't uniform, this impacts the number of values in each rolling window
+    datetimes = (list(pd.date_range(start='2017-01-01', freq='1d', periods=3)) +
+                 list(pd.date_range(start='2017-01-10', freq='2d', periods=4)) +
+                 list(pd.date_range(start='2017-01-22', freq='1d', periods=7)))
+    no_freq_series = pd.Series(range(len(datetimes)), index=datetimes)
+
+    # There will be at least two null values at the beginning of each range's rows, the first for the
+    # row skipped by the gap, and the second because pandas' std returns NaN if there's only one row
+    expected_series = pd.Series([None, None, 0.707107] +
+                                [None, None, None, None] +  # Because the freq was 2 days, there will never be more than 1 observation
+                                [None, None, 0.707107, 1.0, 1.0, 1.0, 1.0])
+
+    primitive_instance = RollingSTD(window_length='3d', gap='1d')
+    rolled_series = pd.Series(primitive_instance(no_freq_series.index, pd.Series(no_freq_series.values)))
+
+    pd.testing.assert_series_equal(rolled_series, expected_series)
+
+
+@pytest.mark.parametrize("primitive", [RollingCount, RollingMax, RollingMin, RollingMean, RollingSTD])
+@patch("featuretools.primitives.rolling_transform_primitive._apply_roll_with_offset_gap")
+def test_no_call_to_apply_roll_with_offset_gap_with_numeric(mock_apply_roll, primitive, rolling_series_pd):
+    assert not mock_apply_roll.called
+
+    fully_numeric_primitive = primitive(window_length=3, gap=1)
+    primitive_func = fully_numeric_primitive.get_function()
+    if isinstance(fully_numeric_primitive, RollingCount):
+        pd.Series(primitive_func(rolling_series_pd.index))
+    else:
+        pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
+
+    assert not mock_apply_roll.called
+
+    offset_window_primitive = primitive(window_length='3d', gap=1)
+    primitive_func = offset_window_primitive.get_function()
+    if isinstance(offset_window_primitive, RollingCount):
+        pd.Series(primitive_func(rolling_series_pd.index))
+    else:
+        pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
+
+    assert not mock_apply_roll.called
+
+    no_gap_specified_primitive = primitive(window_length='3d')
+    primitive_func = no_gap_specified_primitive.get_function()
+    if isinstance(no_gap_specified_primitive, RollingCount):
+        pd.Series(primitive_func(rolling_series_pd.index))
+    else:
+        pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
+
+    assert not mock_apply_roll.called
+
+    no_gap_specified_primitive = primitive(window_length='3d', gap='1d')
+    primitive_func = no_gap_specified_primitive.get_function()
+    if isinstance(no_gap_specified_primitive, RollingCount):
+        pd.Series(primitive_func(rolling_series_pd.index))
+    else:
+        pd.Series(primitive_func(rolling_series_pd.index, pd.Series(rolling_series_pd.values)))
+
+    assert mock_apply_roll.called

--- a/featuretools/tests/primitive_tests/utils.py
+++ b/featuretools/tests/primitive_tests/utils.py
@@ -1,0 +1,17 @@
+def get_number_from_offset(offset):
+    """Extract the numeric element of a potential offset string.
+
+    Args:
+        offset (int, str): If offset is an integer, that value is returned. If offset is a string,
+            it's assumed to be an offset string of the format nD where n is a single digit integer.
+
+    Note: This helper utility should only be used with offset strings that only have one numeric character.
+        Only the first character will be returned, so if an offset string 24H is used, it will incorrectly
+        return the integer 2. Additionally, any of the offset timespans (H for hourly, D for daily, etc.)
+        can be used here; however, care should be taken by the user to remember what that timespan is when
+        writing tests, as comparing 7 from 7D to 1 from 1W may not behave as expected.
+    """
+    if isinstance(offset, str):
+        return int(offset[0])
+    else:
+        return offset

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -426,25 +426,41 @@ def test_bad_groupby_feature(es):
         RollingSTD,
     ]
 )
-def test_make_rolling_features(rolling_primitive, pd_es):
-    rolling_primitive_obj = rolling_primitive(window_length=7, gap=3, min_periods=5)
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (7, 3),
+        ('7d', '3d'),
+    ]
+)
+def test_make_rolling_features(window_length, gap, rolling_primitive, pd_es):
+    rolling_primitive_obj = rolling_primitive(window_length=window_length,
+                                              gap=gap,
+                                              min_periods=5)
     dfs_obj = DeepFeatureSynthesis(target_dataframe_name='log',
                                    entityset=pd_es,
                                    agg_primitives=[],
                                    trans_primitives=[rolling_primitive_obj])
     features = dfs_obj.build_features()
-    rolling_transform_name = f"{rolling_primitive.name.upper()}(datetime, value_many_nans, window_length=7, gap=3, min_periods=5)"
+    rolling_transform_name = f"{rolling_primitive.name.upper()}(datetime, value_many_nans, window_length={window_length}, gap={gap}, min_periods=5)"
     assert feature_with_name(features, rolling_transform_name)
 
 
-def test_make_rolling_count_off_datetime_feature(pd_es):
-    rolling_count = RollingCount(window_length=5, min_periods=3)
+@pytest.mark.parametrize(
+    "window_length, gap",
+    [
+        (7, 3),
+        ('7d', '3d'),
+    ]
+)
+def test_make_rolling_count_off_datetime_feature(window_length, gap, pd_es):
+    rolling_count = RollingCount(window_length=window_length, min_periods=gap)
     dfs_obj = DeepFeatureSynthesis(target_dataframe_name='log',
                                    entityset=pd_es,
                                    agg_primitives=[],
                                    trans_primitives=[rolling_count])
     features = dfs_obj.build_features()
-    rolling_transform_name = u"ROLLING_COUNT(datetime, window_length=5, min_periods=3)"
+    rolling_transform_name = f"ROLLING_COUNT(datetime, window_length={window_length}, min_periods={gap})"
     assert feature_with_name(features, rolling_transform_name)
 
 


### PR DESCRIPTION
…809)

* Add ability to use offset strings in rolling gap util

* handle getting of numer from offset better

* Handle non fixed frequencies

* Add additional test for window length when non uniform

* Update primitive tests broken for count

* Get offset string gap working for count

* Better parameterize rolling count tests

* Add function to handle offset gap

* Stop handling offset gap in main rolling function

* get apply offset function working in rolling max primitive

* clean up apply roll primitive logic

* update primitive util tests

* Update primitives

* Add non uniform primitive tests

* lint fix

* fix logic for determining gap rows

* update docstrings

* lint fix

* Catch breaking mismatched inputs

* Check that string inputs are valid offset strings

* lint fix

* Add release note

* Test varying frequencies

* Add another test

* Add mock test for whether or not apply function gets called

* Update docstring

* update test requirements to include mock

* test dfs with new primitive parameter types

* lint fix

* clean up utils

* clean up tests

* fix typo

* Update arg passing into apply

* Add docstring and rename ofsset string util

* PR comments

* Expand input checking

* test non uniform with multiple instances in a window

* clean up non uniform tests

* MR comments

* lint fix

### Pull Request Description
(replace this text with your description)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request.*
